### PR TITLE
cosemessage: expect EOFError for protected header

### DIFF
--- a/pycose/cosemessage.py
+++ b/pycose/cosemessage.py
@@ -54,7 +54,7 @@ class CoseMessage(BasicCoseStructure, metaclass=abc.ABCMeta):
 
         try:
             decoded_protected_header = cbor.loads(cose_obj.pop(0))
-        except ValueError:
+        except (ValueError, EOFError):
             decoded_protected_header = {}
 
         try:

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='pycose',
-    version='0.1',
+    version='0.1.1',
     packages=find_packages(exclude=['tests']),
     python_requires='>=3.3',
     install_requires=[


### PR DESCRIPTION
cbor library differs in the exception raised when attempting to load an
empty string between its Python and C backends. When using the former
(e.g. on Windows), an EOFError rather than a ValueError is raised.