### PR TITLE
Fix usage of private function in SignMessage

### DIFF
--- a/pycose/crypto.py
+++ b/pycose/crypto.py
@@ -153,7 +153,10 @@ def ec_verify_wrapper(key, to_be_signed, signature, algorithm='ES256', curve='P-
         signer = derive_priv_key(key, ec_curves[curve], hashfunc=hashes_for_ecc[algorithm])
     else:
         signer = key
-    verifier = signer.get_verifying_key()
+    try:
+        verifier = signer.get_verifying_key()
+    except AttributeError:
+        verifier = signer
     return verifier.verify(signature, to_be_signed, hashfunc=hashes_for_ecc[algorithm])
 
 

--- a/pycose/signmessage.py
+++ b/pycose/signmessage.py
@@ -27,7 +27,7 @@ class SignMessage(signcommon.SignCommon):
             copy.deepcopy(u_header),
             payload)
         self._key = key
-        self._signers = self.__convert_to_coseattrs(copy.deepcopy(signers))
+        self._signers = self._BasicCoseStructure__convert_to_coseattrs(copy.deepcopy(signers))
 
     @property
     def key(self):


### PR DESCRIPTION
According to python pep8 `__double_leading_underscore` class attributes get name mangled to `_Class__double_leading_underscore`. This fixes `SignMessage` which calls a private function of a parent.