### PR TITLE
Fix usage of private function in SignMessage

### DIFF
--- a/pycose/signmessage.py
+++ b/pycose/signmessage.py
@@ -27,7 +27,7 @@ class SignMessage(signcommon.SignCommon):
             copy.deepcopy(u_header),
             payload)
         self._key = key
-        self._signers = self.__convert_to_coseattrs(copy.deepcopy(signers))
+        self._signers = self._BasicCoseStructure__convert_to_coseattrs(copy.deepcopy(signers))
 
     @property
     def key(self):


### PR DESCRIPTION
According to python pep8 `__double_leading_underscore` class attributes get name mangled to `_Class__double_leading_underscore`. This fixes SignMessage which calls a private function of a parent.